### PR TITLE
Translation of ch06-01-defining-an-enum.md(Part 2)

### DIFF
--- a/second-edition/src/ch06-01-defining-an-enum.md
+++ b/second-edition/src/ch06-01-defining-an-enum.md
@@ -247,14 +247,15 @@ struct WriteMessage(String); // tuple struct
 struct ChangeColorMessage(i32, i32, i32); // tuple struct
 ```
 
-But if we used the different structs, which each have their own type, we
-wouldn’t be able to as easily define a function that could take any of these
-kinds of messages as we could with the `Message` enum defined in Listing 6-2,
-which is a single type.
+Pero si usamos diferentes estructuras, que cada una tiene su propio tipo, no seriamos
+capaces de definir facilmente una función que podría tomar de estos tipos de
+de mensajes como podriamos con la enumeración `Message` definida en el Listado 6-2,
+que es un solo tipo.
 
-There is one more similarity between enums and structs: just as we’re able to
-define methods on structs using `impl`, we’re also able to define methods on
-enums. Here’s a method named `call` that we could define on our `Message` enum:
+Hay una similitud más entre enumeraciones y estructuras: de la misma forma que somos
+capaces de definir en estructuras usando `impl`, también podemos definir métodos en
+estructuras. Aquí hay un método llamado `call` que podriamos definir en nuestra 
+enumeración `Message`:
 
 ```rust
 # enum Message {
@@ -266,7 +267,7 @@ enums. Here’s a method named `call` that we could define on our `Message` enum
 #
 impl Message {
     fn call(&self) {
-        // method body would be defined here
+        // el cuerpo del método se definiría aquí
     }
 }
 
@@ -274,56 +275,56 @@ let m = Message::Write(String::from("hello"));
 m.call();
 ```
 
-The body of the method would use `self` to get the value that we called the
-method on. In this example, we’ve created a variable `m` that has the value
-`Message::Write(String::from("hello"))`, and that is what `self` will be in the body of the
-`call` method when `m.call()` runs.
+El método del cuerpo usaría `self` para obtener el valor que llamamos el método
+encendido. En este ejemplo, hemos creado una variable `m` que tiene el valor
+`Message::Write(String::from("hello"))`, y eso es lo qué `self` tendrá en el cuerpo
+del método `call` cuando `m.call()` se ejecute.
 
-Let’s look at another enum in the standard library that is very common and
-useful: `Option`.
+Veamos otra enumeración en la biblioteca estándar que es muy común y útil: `Option`
 
-### The `Option` Enum and Its Advantages Over Null Values
+### La enumeración `Option` y sus ventajas sobre valores nulos
 
-In the previous section, we looked at how the `IpAddr` enum let us use Rust’s
-type system to encode more information than just the data into our program.
-This section explores a case study of `Option`, which is another enum defined
-by the standard library. The `Option` type is used in many places because it
-encodes the very common scenario in which a value could be something or it
-could be nothing. Expressing this concept in terms of the type system means the
-compiler can check that you’ve handled all the cases you should be handling,
-which can prevent bugs that are extremely common in other programming languages.
+En la sección previa, hemos visto como la enumeración `IpAddr` nos dejo usar el
+sistema de tipo Rust’s para codificar más información que solo los datos dentro de
+nuestro programa. Esta sección explora un caso de estudio de `Option`, que es otra
+enumeración definida por la biblioteca estándar. El tipo `Option`  es usado en muchos
+lugares porque codifica un escenario muy común en que un valor podría tener algo o podría
+no tener nada. Expresando este concepto en términos del tipo de sistema significa que
+el compilador puede verificar que haya manejado todos los casos que debería manejar,
+que puede prevenir errores que son extremadamente comunes en otros lenguajes de programación.
 
-Programming language design is often thought of in terms of which features you
-include, but the features you exclude are important too. Rust doesn’t have the
-null feature that many other languages have. *Null* is a value that means there
-is no value there. In languages with null, variables can always be in one of
-two states: null or not-null.
+El diseño del lenguaje de programación a menudo se piensa en términos de que características
+incluir, pero las características que excluyes también son importantes. Rust no tiene la 
+característica nula que muchos otros lenguajes tienen. *Null* es un valor que significa que no
+tiene valor allí. En lenguajes con nulo, las variables pueden estar siempre en uno o dos estados: 
+nulo o no nulo.
 
-In “Null References: The Billion Dollar Mistake,” Tony Hoare, the inventor of
-null, has this to say:
 
-> I call it my billion-dollar mistake. At that time, I was designing the first
-> comprehensive type system for references in an object-oriented language. My
-> goal was to ensure that all use of references should be absolutely safe, with
-> checking performed automatically by the compiler. But I couldn’t resist the
-> temptation to put in a null reference, simply because it was so easy to
-> implement. This has led to innumerable errors, vulnerabilities, and system
-> crashes, which have probably caused a billion dollars of pain and damage in
-> the last forty years.
+En “Null References: The Billion Dollar Mistake,” Tony Hoare, el inventor del nulo, tiene
+esto para decir::
 
-The problem with null values is that if you try to actually use a value that’s
-null as if it is a not-null value, you’ll get an error of some kind. Because
-this null or not-null property is pervasive, it’s extremely easy to make this
-kind of error.
+> Yo llamo esto mi error billonario. En ese momento, estaba diseñando el 
+> sistema de tipo completo para referencias en un lenguaje oriendato a objetos. Mi
+> objetivo fue asegurar que todo el uso de referencias debería ser absolutamente
+> seguro, con verificacion realizada automáticamente por el compilador. Pero no pude
+> reistir la  de poner en una referencia nula, simplemente porque era más fácil de
+> implementar. Esto ha ocasionado innumerables errores, vulnerabilidades y fallos del
+> sistema, que probablemente hayan causado un billón de dolares de dolor y daño en
+> los últimos 40 años.
 
-However, the concept that null is trying to express is still a useful one: a
-null is a value that is currently invalid or absent for some reason.
+El problema con los valores nulos es que si intentas usar un valor que es nulo como si
+no fuera un valor nulo, obtendrás un error de algún tipo. Porque esta propiedad nula o no nula 
+es penetrante, es extremadamente fácil hacer este tipo de error.
 
-The problem isn’t with the actual concept but with the particular
-implementation. As such, Rust does not have nulls, but it does have an enum
-that can encode the concept of a value being present or absent. This enum is
-`Option<T>`, and it is [defined by the standard library][option]<!-- ignore -->
-as follows:
+
+Sin embargo, el concepto que nulo está intentando intentando expresar sigue siendo útil: un
+nulo es un valor que es actualmente inválido o está ausente por alguna razón.
+
+El problema no es con el concepto actual sino con la particular implementación. Como tal, Rust
+no tiene nulos, pero tiene una enumeración que puede codificar el concepto de un valor
+estando presente o ausente. Esta enumeración es
+`Option<T>`, y es [definida por la bibliotca estándar][option]<!-- ignorar -->
+de la siguiente manera:
 
 [option]: ../../std/option/enum.Option.html
 
@@ -334,17 +335,17 @@ enum Option<T> {
 }
 ```
 
-The `Option<T>` enum is so useful that it’s even included in the prelude; you
-don’t need to bring it into scope explicitly. In addition, so are its variants:
-you can use `Some` and `None` directly without prefixing them with `Option::`.
-`Option<T>` is still just a regular enum, and `Some(T)` and `None` are still
-variants of type `Option<T>`.
+La enumeración `Option<T>` es tan útil que está incluida incluso en el preludio; no necesitas
+incluirla en el alcance explicitamente. Además, también lo son sus variantes:
+puedes usar `Some` y `None` directamente sin prefijarlos con `Option::`.
+`Option<T>` sigue siendo solo una enumeración regular, y `Some(T)` y `None` siguen siendo
+variantes de tipo `Option<T>`.
 
-The `<T>` syntax is a feature of Rust we haven’t talked about yet. It’s a
-generic type parameter, and we’ll cover generics in more detail in Chapter 10.
-For now, all you need to know is that `<T>` means the `Some` variant of the
-`Option` enum can hold one piece of data of any type. Here are some examples of
-using `Option` values to hold number types and string types:
+La sintaxis `<T>` es una característica de Rust que aún no hemos hablado. Es un parametro
+de tipo genérico, y cubriremos genericos en más detalles en el capítulo 10.
+Por ahora, todo lo que necesitas saber es que `<T>` significa la variante `Some` de 
+la enumeración `Option` que puede contener una pieza de datos de cualquier tipo. Aquí
+hay algunos ejemplos de usando los valores `Option` para contener tipos de números y tipos de cadenas:
 
 ```rust
 let some_number = Some(5);
@@ -353,19 +354,20 @@ let some_string = Some("a string");
 let absent_number: Option<i32> = None;
 ```
 
-If we use `None` rather than `Some`, we need to tell Rust what type of
-`Option<T>` we have, because the compiler can’t infer the type that the `Some`
-variant will hold by looking only at a `None` value.
+Si usamos `None` en vez de `Some`, necesitamos decirle a Rust que tipo de
+`Option<T>` tenemos, porque el compilador no puede deducir el tipo que la variante `Some`
+se quedará mirando solo al valor `None`.
 
-When we have a `Some` value, we know that a value is present, and the value is
-held within the `Some`. When we have a `None` value, in some sense, it means
-the same thing as null: we don’t have a valid value. So why is having
-`Option<T>` any better than having null?
+Cuando tenemos un valor `Some`, sabemos que un valor está presente, y el valor es
+se produce dentro de `Some`. Cuando tenemos un valor `None`, en cierto sentido, esto significa
+lo mismo que nulo: no tenemos un valor válido. Entonces por qué `Option<T>` no está
+teniendo nada mejor que nulo?
 
-In short, because `Option<T>` and `T` (where `T` can be any type) are different
-types, the compiler won’t let us use an `Option<T>` value as if it was
-definitely a valid value. For example, this code won’t compile because it’s
-trying to add an `i8` to an `Option<i8>`:
+
+En conclusión, porque `Option<T>` y `T` (donde `T` puede ser de cualquier tipo) son tipos
+diferentes, el compilador no le dejará usar un valor `Option<T>` como si este fuera
+definitivamente un valor válido. Por ejemplo, este código no se compilará porque está
+tratando de agregar un `i8` a un `Option<i8>`:
 
 ```rust,ignore
 let x: i8 = 5;
@@ -374,7 +376,7 @@ let y: Option<i8> = Some(5);
 let sum = x + y;
 ```
 
-If we run this code, we get an error message like this:
+Si ejecutamos este código, recibimos un mensaje de error como este:
 
 ```text
 error[E0277]: the trait bound `i8: std::ops::Add<std::option::Option<i8>>` is
@@ -386,28 +388,27 @@ not satisfied
   |
 ```
 
-Intense! In effect, this error message means that Rust doesn’t understand how
-to add an `i8` and an `Option<i8>`, because they’re different types. When we
-have a value of a type like `i8` in Rust, the compiler will ensure that we
-always have a valid value. We can proceed confidently without having to check
-for null before using that value. Only when we have an `Option<i8>` (or
-whatever type of value we’re working with) do we have to worry about possibly
-not having a value, and the compiler will make sure we handle that case before
-using the value.
+Intenso! En efecto, este mensaje de error significa que Rust no etiende como
+agregar un `i8` y un `Option<i8>`, porque son diferentes tipos. Cuando tenemos
+un valor de un tipo como `i8` en Rust, el compilador se asegurará que
+siempre tengamos un valor válido. Podemos proceder con confianza sin tener que
+verificar para nulo antes de usar ese valor. Solo cuando tenemos una `Option<i8>` (o
+cualquier tipo de valor con el que estemos trabajando) tenemos que tener cuidado
+con la posibilidad de no tener un valor, y el compilador se asegurará que manejamos
+ese caso antes de usar el valor.
 
-In other words, you have to convert an `Option<T>` to a `T` before you can
-perform `T` operations with it. Generally, this helps catch one of the most
-common issues with null: assuming that something isn’t null when it actually
-is.
+En otras palabras, debes convetir una `Option<T>` en una `T` antes de poder
+realizar operaciones `T` con el. Generalmente, estas ayudas a atrapar uno de los 
+errores más comunes con nulos: asumiendo que algo no es nulo cuando realmente lo es.
 
-Not having to worry about missing an assumption of having a not-null value
-helps you to be more confident in your code. In order to have a value that can
-possibly be null, you must explicitly opt in by making the type of that value
-`Option<T>`. Then, when you use that value, you are required to explicitly
-handle the case when the value is null. Everywhere that a value has a type that
-isn’t an `Option<T>`, you *can* safely assume that the value isn’t null. This
-was a deliberate design decision for Rust to limit null’s pervasiveness and
-increase the safety of Rust code.
+No se preocupe sobre por perder la suposición de que tener un valor no nulo
+ayuda a tener más confianza en tu código. Para tener un valor que pueda ser posiblemente
+nulo, debe optar explicitamente en seguir haciendo el tipo del valor
+`Option<T>`. Luego, cuando uses ese valor, se requiere manejar explicitamente
+el caso cuando el valor es nulo. En todo lugar que un valor tiene un tipo que
+no es una `Option<T>`, usted *can* puede asumir con toda seguridad que el valor no es nulo.
+Esta fue una decisión de diseño deliberada para Rust para limitar la penetrabilidad de nulos
+e incrementar la seguridad del código Rust.
 
 So, how do you get the `T` value out of a `Some` variant when you have a value
 of type `Option<T>` so you can use that value? The `Option<T>` enum has a large


### PR DESCRIPTION
second part of the Spanish translation of ch06-01-defining-an-enum.md


